### PR TITLE
php 7 compliant

### DIFF
--- a/src/Schuppo/PasswordStrength/PasswordStrengthServiceProvider.php
+++ b/src/Schuppo/PasswordStrength/PasswordStrengthServiceProvider.php
@@ -31,7 +31,7 @@ class PasswordStrengthServiceProvider extends ServiceProvider {
         foreach(['letters', 'numbers', 'caseDiff', 'symbols'] as $rule)
         {
             $camelCasedRule = snake_case($rule);
-            $validator->extend($rule, function ($_, $value, $_) use ($passwordStrength, $rule) {
+            $validator->extend($rule, function ($_, $value, $__) use ($passwordStrength, $rule) {
                 $capitalizedRule = ucfirst($rule);
                 return call_user_func([$passwordStrength, "validate$capitalizedRule"], $value);
             }, $translator->get("password-strength::validation.$camelCasedRule"));


### PR DESCRIPTION
This PR simply correct the following PHP 7 error

```bash
PHP Fatal error:  Redefinition of parameter $_ in 
..../vendor/schuppo/password-strength/src/Schuppo/PasswordStrength/PasswordStrengthServiceProvider.php 
on line 34
```