### PR TITLE
Add slash to symbol characters

### DIFF
--- a/src/Schuppo/PasswordStrength/PasswordStrength.php
+++ b/src/Schuppo/PasswordStrength/PasswordStrength.php
@@ -21,6 +21,6 @@ class PasswordStrength
 
     public function validateSymbols($value)
     {
-        return preg_match('/[!@#$%^&*?()\-_=+{};:,<.>\/]/', $value);
+        return preg_match('/[!@#$%^&*?()\-_=+{};:,<.>\/\\\]/', $value);
     }
 }

--- a/src/Schuppo/PasswordStrength/PasswordStrength.php
+++ b/src/Schuppo/PasswordStrength/PasswordStrength.php
@@ -21,6 +21,6 @@ class PasswordStrength
 
     public function validateSymbols($value)
     {
-        return preg_match('/[!@#$%^&*?()\-_=+{};:,<.>]/', $value);
+        return preg_match('/[!@#$%^&*?()\-_=+{};:,<.>\/]/', $value);
     }
 }

--- a/tests/Schuppo/PasswordStrength/PasswordStrengthTest.php
+++ b/tests/Schuppo/PasswordStrength/PasswordStrengthTest.php
@@ -4,7 +4,7 @@ namespace Schuppo\PasswordStrength;
 
 use Illuminate\Translation\ArrayLoader;
 use Illuminate\Translation\Translator;
-use  \Illuminate\Validation\Factory;
+use Illuminate\Validation\Factory;
 
 /**
  * PasswordStrengthTest
@@ -50,11 +50,21 @@ class PasswordStrengthTest extends \PHPUnit_Framework_TestCase
 
     public function test_symbols_succeeds_with_symbol()
     {
-        $validation = $this->validation->make(
-            array( 'password' => '@' ),
-            array( 'password' => 'symbols' )
-        );
-        $this->assertTrue($validation->passes());
+    	$symbols = array(
+    		'!', '@', '#', '$', '%',
+			'^', '&', '*', '?', '(',
+			')', '-', '_, ', '=', '+',
+			'{', '}', ';', ':', ',',
+			'<', '.', '>', '\\', '/'
+		);
+
+    	foreach($symbols as $symbol) {
+			$validation = $this->validation->make(
+				array( 'password' => $symbol ),
+				array( 'password' => 'symbols' )
+			);
+			$this->assertTrue($validation->passes());
+		}
     }
 
     public function test_case_diff_fails_just_lowercase()
@@ -106,7 +116,16 @@ class PasswordStrengthTest extends \PHPUnit_Framework_TestCase
     public function test_numbers_succeeds()
     {
         $validation = $this->validation->make(
-            array( 'password' => '1' ),
+            array( 'password' => 1 ),
+            array( 'password' => 'numbers' )
+        );
+        $this->assertTrue($validation->passes());
+    }
+
+    public function test_numbers_succeeds_float()
+    {
+        $validation = $this->validation->make(
+            array( 'password' => 1.1 ),
             array( 'password' => 'numbers' )
         );
         $this->assertTrue($validation->passes());


### PR DESCRIPTION
Passwords which only contain a slash as symbol currently do fail the validateSymbols category. Therefore the missing slash has been added to the symbols regex