### PR TITLE
Simplify symbol validation

### DIFF
--- a/src/Schuppo/PasswordStrength/PasswordStrength.php
+++ b/src/Schuppo/PasswordStrength/PasswordStrength.php
@@ -21,6 +21,6 @@ class PasswordStrength
 
     public function validateSymbols($value)
     {
-        return preg_match('/[!@#$%^&*?()\-_=+{};:,<.>\/\\\]/', $value);
+        return preg_match('/\p{Z}|\p{S}|\p{P}/', $value);
     }
 }

--- a/tests/Schuppo/PasswordStrength/PasswordStrengthTest.php
+++ b/tests/Schuppo/PasswordStrength/PasswordStrengthTest.php
@@ -51,20 +51,21 @@ class PasswordStrengthTest extends \PHPUnit_Framework_TestCase
     public function test_symbols_succeeds_with_symbol()
     {
     	$symbols = array(
-    		'!', '@', '#', '$', '%',
-			'^', '&', '*', '?', '(',
-			')', '-', '_, ', '=', '+',
-			'{', '}', ';', ':', ',',
-			'<', '.', '>', '\\', '/'
+            '!', '@', '#', '$', '%',
+            '^', '&', '*', '?', '(',
+            ')', '-', '_, ', '=', '+',
+            '{', '}', ';', ':', ',',
+            '<', '.', '>', '\\', '/',
+            ' ', "\t"
 		);
 
-    	foreach($symbols as $symbol) {
-			$validation = $this->validation->make(
-				array( 'password' => $symbol ),
-				array( 'password' => 'symbols' )
-			);
-			$this->assertTrue($validation->passes());
-		}
+        foreach($symbols as $symbol) {
+            $validation = $this->validation->make(
+                array( 'password' => $symbol ),
+                array( 'password' => 'symbols' )
+            );
+            $this->assertTrue($validation->passes());
+        }
     }
 
     public function test_case_diff_fails_just_lowercase()


### PR DESCRIPTION
In order to simplify the symbol validation and be consistent to acknowledge the same symbols as other validation libraries, the universal groups for symbols should be used instead of specifically whitelisting some symbols.