### PR TITLE
Remove the need for the Str facade

### DIFF
--- a/src/Schuppo/PasswordStrength/PasswordStrengthServiceProvider.php
+++ b/src/Schuppo/PasswordStrength/PasswordStrengthServiceProvider.php
@@ -4,6 +4,7 @@ namespace Schuppo\PasswordStrength;
 
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use Illuminate\Translation\Translator;
 
 class PasswordStrengthServiceProvider extends ServiceProvider
@@ -35,7 +36,7 @@ class PasswordStrengthServiceProvider extends ServiceProvider
         $translator = app('passwordStrength.translationProvider')->get($validator);
 
         foreach(['letters', 'numbers', 'caseDiff', 'symbols'] as $rule) {
-            $snakeCasedRule = \Str::snake($rule);
+            $snakeCasedRule = Str::snake($rule);
 
             $validator->extend($rule, function ($_, $value, $__) use ($passwordStrength, $rule) {
                 $capitalizedRule = ucfirst($rule);


### PR DESCRIPTION
In commit 0ae24ba87a81ed9ed1ff4368a31af5a1850566a8 the need for the Str facade was added. This can break existing code.

This fixes that.